### PR TITLE
Supported containers 0.6.*.

### DIFF
--- a/MiniAgda.cabal
+++ b/MiniAgda.cabal
@@ -50,7 +50,7 @@ executable miniagda
   hs-source-dirs:   src
   build-depends:    array >= 0.3 && < 0.6,
                     base >= 4.6 && < 5,
-                    containers >= 0.3 && < 0.6,
+                    containers >= 0.3 && < 0.7,
                     haskell-src-exts >= 1.21 && < 1.22,
                     mtl >= 2.2.2 && < 2.3,
                     pretty >= 1.0 && < 1.2


### PR DESCRIPTION
The version of containers in GHC 8.6.4 is 0.6.0.1, so I included this version in the `.cabal` file.