### PR TITLE
ghc 9.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,34 +8,58 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.202211107
+# version: 0.19.20250506
 #
-# REGENDATA ("0.15.202211107",["github","MiniAgda.cabal"])
+# REGENDATA ("0.19.20250506",["github","MiniAgda.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.3
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.4.3
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.5
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.2.5
+            compilerVersion: 9.10.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.8.4
+            compilerKind: ghc
+            compilerVersion: 9.8.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.7
+            compilerKind: ghc
+            compilerVersion: 9.6.7
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.8
+            compilerKind: ghc
+            compilerVersion: 9.4.8
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -51,54 +75,53 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -109,28 +132,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -173,14 +180,14 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -208,15 +215,15 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(MiniAgda|mtl|transformers)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(MiniAgda)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -240,8 +247,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,10 +1,11 @@
 # 2022-05-14, https://github.com/freckle/stack-action
+# 2025-07-23 updated to @v5
 
 name: Stack
 
 on:
   push:
-    branches: [ master, ci-* ]
+    branches: [ master ]
     tags:     [ v* ]
   pull_request:
     types: [ opened, synchronize ]
@@ -18,26 +19,22 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ubuntu-22.04]
-        ghc: [9.4.3, 9.2.5, 9.0.2, 8.10.7]
+        ghc: ['9.12', '9.10', '9.8', '9.6']
         include:
           - os:  macOS-latest
-            ghc: 9.4.3
+            ghc: '9.12'
           - os:  windows-latest
-            ghc: 9.4.3
+            ghc: '9.12'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # - uses: andreasabel/fix-whitespace-action@master
 
-      - uses: freckle/stack-cache-action@v2
+      - uses: freckle/stack-action@v5
         with:
           stack-yaml: stack-${{ matrix.ghc }}.yaml
-          prefix: stack-
-
-      - uses: freckle/stack-action@v3
-        with:
-          stack-yaml: stack-${{ matrix.ghc }}.yaml
-          pedantic: false
-            # no --pendantic flag (meaning -Wall -Werror)
-            # does not respect our -fno-warn- ghc options
+          stack-build-arguments: --fast
+            # Set stack-build-arguments to clear the --pendantic flag (meaning -Wall -Werror).
+            # It does not respect our -Wno- ghc options.
+          cache-save-always: true

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 CHANGELOG for MiniAgda
 
-unreleased    Drop support for GHC 7.6 and 7.8
+0.2025.7.23   Drop support for GHC 7, tested with GHC 8.0 - 9.12.2.
 
 0.2022.3.11   Fixed compilation with mtl-2.3-rc3, tested with ghc 9.2.2, added cabal test.
 

--- a/MiniAgda.cabal
+++ b/MiniAgda.cabal
@@ -1,7 +1,7 @@
 cabal-version:   2.4
   -- 2.4 introduces the ** glob patterns used in data-files
 name:            MiniAgda
-version:         0.2022.4.6
+version:         0.2025.7.23
 build-type:      Simple
 license:         MIT
 license-file:    LICENSE
@@ -45,6 +45,10 @@ extra-doc-files:
 extra-source-files:
   Makefile
   src/Makefile
+  stack-9.12.yaml
+  stack-9.10.yaml
+  stack-9.8.yaml
+  stack-9.6.yaml
   stack-9.4.3.yaml
   stack-9.2.5.yaml
   stack-9.0.2.yaml
@@ -67,7 +71,7 @@ library
   hs-source-dirs:       src
   build-depends:        array             >= 0.3    && < 0.6
                       , base              >= 4.9    && < 5
-                      , containers        >= 0.3    && < 0.8
+                      , containers        >= 0.3    && < 1
                       , haskell-src-exts  >= 1.21   && < 1.22
                           -- haskell-src-exts is a nervous package with incompatibilities
                           -- in every new version, thus, we need tight bounds.

--- a/MiniAgda.cabal
+++ b/MiniAgda.cabal
@@ -24,8 +24,12 @@ description:
   patterns for a more general handling of coinduction.
 
 tested-with:
-  GHC == 9.4.3
-  GHC == 9.2.5
+  GHC == 9.12.2
+  GHC == 9.10.2
+  GHC == 9.8.4
+  GHC == 9.6.7
+  GHC == 9.4.8
+  GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -33,11 +37,12 @@ tested-with:
   GHC == 8.4.4
   GHC == 8.2.2
   GHC == 8.0.2
-  GHC == 7.10.3
 
-extra-source-files:
+extra-doc-files:
   CHANGELOG
   README.md
+
+extra-source-files:
   Makefile
   src/Makefile
   stack-9.4.3.yaml
@@ -61,8 +66,8 @@ source-repository head
 library
   hs-source-dirs:       src
   build-depends:        array             >= 0.3    && < 0.6
-                      , base              >= 4.8    && < 5
-                      , containers        >= 0.3    && < 0.7
+                      , base              >= 4.9    && < 5
+                      , containers        >= 0.3    && < 0.8
                       , haskell-src-exts  >= 1.21   && < 1.22
                           -- haskell-src-exts is a nervous package with incompatibilities
                           -- in every new version, thus, we need tight bounds.
@@ -74,11 +79,7 @@ library
                       , string-qq
                       , transformers
 
-  if impl(ghc < 8)
-    build-depends:      semigroups        >= 0.5    && < 1
-                          -- semigroups-0.5 adds Data.List.NonEmpty
-
-  build-tool-depends:   happy:happy       >= 1.15   && < 2
+  build-tool-depends:   happy:happy       >= 1.15   && < 3
                       , alex:alex         >= 3.0    && < 4
 
   default-language:     Haskell98
@@ -124,15 +125,14 @@ library
   autogen-modules:      Paths_MiniAgda
 
   ghc-options:          -Wall
-                        -fno-warn-type-defaults
-                        -fno-warn-dodgy-imports
-                        -fno-warn-unused-binds
-                        -fno-warn-unused-matches
-                        -fno-warn-name-shadowing
-                        -fno-warn-incomplete-patterns
+                        -Wcompat
+                        -Wno-type-defaults
+                        -Wno-dodgy-imports
+                        -Wno-unused-binds
+                        -Wno-unused-matches
+                        -Wno-name-shadowing
+                        -Wno-incomplete-patterns
 
-  if impl(ghc >= 8.0)
-    ghc-options:        -Wcompat
   if impl(ghc >= 9.2)
     ghc-options:        -Wno-incomplete-uni-patterns
                         -Wno-incomplete-record-updates
@@ -148,7 +148,7 @@ test-suite test
   main-is:              GoldplateTests.hs
   default-language:     Haskell2010
   ghc-options:          -threaded
-  build-depends:        base >= 4.11
+  build-depends:        base >= 4.11 && < 5
                           -- goldplate requires ghc >= 8.4
                       , process
   build-tool-depends:   goldplate:goldplate >= 0.2

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ You can install with `stack` from source though, see next section.
      stack build --stack-yaml=stack-$GHCVER.yaml
      stack test  --stack-yaml=stack-$GHCVER.yaml
      ```
-     At the time of writing (2022-05-14), `GHCVER` can be any of `8.8.4`, `8.10.7`, `9.0.2`, or `9.2.2`.
+     At the time of writing (2025-07-23), `GHCVER` can be any of `9.12`, `9.10`, `9.8`, `9.6`, and some older ones.
 
      After building, you can run MiniAgda locally, e.g.:
      ```
-     stack run --stack-yaml=stack-9.2.2.yaml -- examples/Gcd/gcd.ma
+     stack run --stack-yaml=stack-9.12.yaml -- examples/Gcd/gcd.ma
      ```
      You can copy `stack-$GHCVER.yaml` for your choice of `GHCVER` into `stack.yaml` and drop the `--stack-yaml` argument from `stack` invocation.
 
@@ -74,7 +74,6 @@ You can install with `stack` from source though, see next section.
      ```
      stack install --stack-yaml=stack-$GHCVER.yaml
      ```
-     At the time of writing (2022-05-14), `GHCVER` can be any of `8.8.4`, `8.10.7`, `9.0.2`, or `9.2.2`.
 
    Note that the respective installation directory should be on your PATH.
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,4 +1,5 @@
-installed: +all -mtl -transformers
+branches: master
+installed: +all
 tests: >= 8.4
   -- goldplate only compiles with GHC-8.4 and up
 

--- a/stack-9.10.yaml
+++ b/stack-9.10.yaml
@@ -1,0 +1,4 @@
+resolver: lts-24.1
+
+extra-deps:
+- haskell-src-exts-1.21.1

--- a/stack-9.12.yaml
+++ b/stack-9.12.yaml
@@ -1,0 +1,5 @@
+resolver: nightly-2025-07-23
+
+extra-deps:
+- haskell-src-exts-1.21.1
+- goldplate-0.2.2.1@rev:2

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,0 +1,4 @@
+resolver: lts-22.44
+
+extra-deps:
+- haskell-src-exts-1.21.1

--- a/stack-9.8.yaml
+++ b/stack-9.8.yaml
@@ -1,0 +1,4 @@
+resolver: lts-23.27
+
+extra-deps:
+- haskell-src-exts-1.21.1


### PR DESCRIPTION
- **Update stack CI to GHC 9.6 - 9.12**
  

- **Drop support for GHC 7**
  
Candidate: https://hackage.haskell.org/package/MiniAgda-0.2025.7.23/candidate