### PR TITLE
Bump Haskell CI to GHC 9.14.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20260104
 #
-# REGENDATA ("0.19.20250506",["github","MiniAgda.cabal"])
+# REGENDATA ("0.19.20260104",["github","MiniAgda.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -32,14 +35,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.2
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.10.2
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -110,8 +118,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -187,7 +195,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -212,7 +220,9 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_MiniAgda}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package MiniAgda" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package MiniAgda" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(MiniAgda)$/; }' >> cabal.project.local

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:  [ubuntu-22.04]
+        os:  [ubuntu-latest]
         ghc: ['9.12', '9.10', '9.8', '9.6']
         include:
           - os:  macOS-latest

--- a/MiniAgda.cabal
+++ b/MiniAgda.cabal
@@ -24,8 +24,9 @@ description:
   patterns for a more general handling of coinduction.
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
-  GHC == 9.10.2
+  GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8
@@ -81,7 +82,6 @@ library
                           -- optparse-applicative-0.16.0.0 adds some1
                       , pretty            >= 1.0    && < 1.2
                       , string-qq
-                      , transformers
 
   build-tool-depends:   happy:happy       >= 1.15   && < 3
                       , alex:alex         >= 3.0    && < 4

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,4 +1,6 @@
 branches: master
+error-incomplete-patterns: False
+
 installed: +all
 tests: >= 8.4
   -- goldplate only compiles with GHC-8.4 and up


### PR DESCRIPTION
Blocked on:
- aeson https://github.com/haskell/aeson/issues/1155